### PR TITLE
Let algorithmia use json >= 1.8

### DIFF
--- a/algorithmia.gemspec
+++ b/algorithmia.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 11.1"
   spec.add_development_dependency "rspec", "~> 3.4"
 
-  spec.add_dependency "json", "~> 2.0"
+  spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "httparty", "~> 0.13"
-
 end


### PR DESCRIPTION
https://github.com/algorithmiaio/algorithmia-ruby/pull/20 forced support for `json ~> 2.0` but there's no apparent reason to discard the previous version of the gem, considering that many gems on Rubygems are using that.

This way the dependency is less conservative.